### PR TITLE
Support for MacOs X and to work after midnight

### DIFF
--- a/app/lib/lockedData.js
+++ b/app/lib/lockedData.js
@@ -32,7 +32,7 @@ let logMidnightLockData = function logMidnightLockData(){
     return ;
   }
 
-  let yesterdayVeryLate = moment().subtract(1, "day").endOf('day')
+  let yesterdayVeryLate = moment().subtract(1, 'day').endOf('day')
 
   // Flag the computer as locked yesterday at midnight
   lockedData.addData(true, yesterdayVeryLate, function(err, res){

--- a/app/lib/lockedData.js
+++ b/app/lib/lockedData.js
@@ -1,24 +1,57 @@
 'use strict'
 
-var jsonfile = require('jsonfile')
-var moment = require('moment')
-var fs = require('fs')
-var path = require('path')
-var mkdirp = require('mkdirp')
-var EventEmitter = require('events').EventEmitter
-var os = require('os')
+const jsonfile = require('jsonfile')
+const moment = require('moment')
+const fs = require('fs')
+const path = require('path')
+const mkdirp = require('mkdirp')
+const EventEmitter = require('events').EventEmitter
+const os = require('os')
 const isDev = require('electron-is-dev')
 
-var globalSettings = require('./globalSettings')
+const globalSettings = require('./globalSettings')
 
-var lockedData = new EventEmitter()
+const lockedData = new EventEmitter()
+lockedData.isLocked = false
+
 module.exports = lockedData
 
-var folder = path.join(os.homedir(), 'timesheet-hero/dates')
+const folder = path.join(os.homedir(), 'timesheet-hero/dates')
+
+
+let getMillisecondsUntilMidnight = function getMillisecondsUntilMidnight(){
+  let now = moment();
+  let midnight = moment().endOf('day');
+  return Math.abs(midnight.diff(now, 'milliseconds'));
+}
+
+let logMidnightLockData = function logMidnightLockData(){
+  setTimeout(logMidnightLockData, 24 * 3600 * 1000) // Call myself 24 hours from now on.
+  if(lockedData.isLocked){
+    // When the computer is locked at midnight, do nothing.
+    return ;
+  }
+
+  let yesterdayVeryLate = moment().subtract(1, "day").endOf('day')
+
+  // Flag the computer as locked yesterday at midnight
+  lockedData.addData(true, yesterdayVeryLate, function(err, res){
+    // Flag the computer as unlocked today at 00:00:00
+    let lastNight = moment().startOf('day')
+    lockedData.addData(false, lastNight, function(err, res){
+        return ;
+    })
+  })
+
+}
+// Call the midnight monitor at midnight.
+setTimeout(logMidnightLockData, getMillisecondsUntilMidnight())
 
 lockedData.addData = function (isLocked, date, callback) {
   if (!date) {
     date = moment()
+    // Save the actual status, to be used at midnight.
+    lockedData.isLocked = isLocked
   }
 
   getFilePath(date, function (err, filePath) {
@@ -194,6 +227,7 @@ lockedData.load = function (date, callback) {
     if (err) { return callback(err) }
 
     fs.access(filePath, function (err) {
+
       if (err && err.code === 'ENOENT') {
         console.log('Creating new file with name: ', getFileName(date))
         globalSettings.get('defaultHoursToWork', function (err, defaultHoursToWork) {
@@ -210,6 +244,7 @@ lockedData.load = function (date, callback) {
       }
 
       jsonfile.readFile(filePath, function (err, data) {
+
         if (!data.weekPlan) {
           data.weekPlan = getDefaultWeekPlan(date, data.hoursToWork)
         }

--- a/app/lib/macOs/sessionStateDetector.js
+++ b/app/lib/macOs/sessionStateDetector.js
@@ -1,12 +1,27 @@
 'use strict'
+const quartz = require('osx-quartz') // https://www.npmjs.com/package/osx-quartz
+      , sessionStateDetector = {}
+      
+let previousLockStatus = true;
 
-var sessionStateDetector = {}
 module.exports = sessionStateDetector
 
 sessionStateDetector.startTracking = function (stateChangedCallback) {
-  // stateChangedCallback(bool);
+
+
+  let monitorLockState = () => {
+    let actualLockStatus = quartz.isScreenLocked();
+    if(actualLockStatus != previousLockStatus) {
+      // Upon a change, call the callback
+      previousLockStatus = actualLockStatus;
+      stateChangedCallback(previousLockStatus);
+    }
+  }
+
+  this.intervalId = setInterval(monitorLockState, 2000) // Run every 2 seconds
+  // https://gist.github.com/abhishekjairath/8bfb259c681ef52545b32c88db6336f5
 }
 
 sessionStateDetector.stopTracking = function () {
-
+  clearInterval(this.intervalId)
 }

--- a/app/lib/macOs/sessionStateDetector.js
+++ b/app/lib/macOs/sessionStateDetector.js
@@ -1,13 +1,12 @@
 'use strict'
 const quartz = require('osx-quartz') // https://www.npmjs.com/package/osx-quartz
       , sessionStateDetector = {}
-      
+
 let previousLockStatus = true;
 
 module.exports = sessionStateDetector
 
 sessionStateDetector.startTracking = function (stateChangedCallback) {
-
 
   let monitorLockState = () => {
     let actualLockStatus = quartz.isScreenLocked();
@@ -18,7 +17,7 @@ sessionStateDetector.startTracking = function (stateChangedCallback) {
     }
   }
 
-  this.intervalId = setInterval(monitorLockState, 2000) // Run every 2 seconds
+  this.intervalId = setInterval(monitorLockState, 10000) // Run every 10 seconds
   // https://gist.github.com/abhishekjairath/8bfb259c681ef52545b32c88db6336f5
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,8 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.18.1",
     "node-notifier": "^5.1.2",
-    "node-osascript": "^2.0.0"
+    "node-osascript": "^2.0.0",
+    "osx-quartz": "^1.0.0"
   },
   "scripts": {
     "start": "electron ."


### PR DESCRIPTION
Added a way to monitor OSX lock screen.
It pulls state every 10 seconds, unlike the Windows version which is Event Based.

There are ways of doing this event-based in OSX, but the node implementation I found still pulls rather than listening to the events. Therefore I decided to keep it easy and use Quartz.

I'm also fixing the issue reported by Nick, issue #1 , regarding working past midnight. But if Nick needs to stay until midnight at the office, maybe there are other issues that need to be solved first.